### PR TITLE
Configure OpenJDK 11 to be used

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11


### PR DESCRIPTION
This PR adds `system.properties` to make sure that Heroku uses OpenJDK 11.