### PR TITLE
Switch content-type to application/x-ndjson

### DIFF
--- a/src/main/kotlin/works/nobushi/beacon/epoch/EpochBeaconController.kt
+++ b/src/main/kotlin/works/nobushi/beacon/epoch/EpochBeaconController.kt
@@ -11,7 +11,7 @@ class EpochBeaconController(
     private val service: EpochBeaconService
 ) {
 
-    @GetMapping("/epoch", produces = [MediaType.APPLICATION_STREAM_JSON_VALUE])
+    @GetMapping("/epoch", produces = [MediaType.APPLICATION_NDJSON_VALUE])
     @MessageMapping("epoch")
     fun epoch(): Flux<Epoch> = service.epoch()
 }


### PR DESCRIPTION
This PR switches the content type to `application/x-ndjson`, because `application/stream+json` is deprecated.