### PR TITLE
Fix build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
         resolutionStrategy.activateDependencyLocking()
     }
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -29,7 +29,7 @@ group = "works.nobushi"
 version = "0.1.0-SNAPSHOT"
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 springBoot {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ tasks {
 
     jacocoTestReport {
         reports {
-            xml.isEnabled = System.getenv("CI") == "true"
+            xml.required.set(System.getenv("CI") == "true")
         }
     }
 


### PR DESCRIPTION
This resolves the deprecation warnings in `build.gradle.kts`.

- [Use `mavenCentral` instead of `jcenter`](https://github.com/kou64yama/beacon/commit/3b33969ba7a553c1fd7f7d2f6373e38ff40bbbee)
- [Use `xml.required.set` instead of `xml.isEnabled`](https://github.com/kou64yama/beacon/commit/17eca71aa885ca9c09e85997513ceaf858c7d77d)